### PR TITLE
Add usage example for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,26 @@ If you don't want to install various Perl deps on your system, build a Docker im
 ```console
 docker build -t photo_prism_yaml_to_exif:latest .
 ```
+
+## Using Docker image
+
+Run the Docker image and use volumes to mount your PhotoPrism originals and sidecar directories.
+
+In this example, both my originals and sidecar directories are under the same directory, so I am only using one volume.
+My host system is running SELinux (Fedora Linux) so I also had to add the `:z` option for permissions to work.
+
+```console
+docker run -it -v /home/jonathan/Downloads/photoprism-snapshot:/photos:z djjudas21/photo_prism_yaml_to_exif bash
+```
+
+Once the container is running, the script can be run in the usual way:
+
+```console
+root@c077d6ed1882:/usr/src/app# perl photo_prism_yaml_to_exif.pl --image_dir /photos/originals/ --yaml_dir /photos/sidecar/ --log_level info
+Dropping privleges to 0:0
+writing YAML data into EXIF for file "/photos/originals/2014/09/20140912_210541_E7EA5C08.jpg"
+writing YAML data into EXIF for file "/photos/originals/2014/09/20140913_135330_68981765.jpg"
+writing YAML data into EXIF for file "/photos/originals/2014/09/20140912_162729_CDEC749D.jpg"
+writing YAML data into EXIF for file "/photos/originals/2014/09/20140912_162729_C1D2F3C5.jpg"
+...
+```


### PR DESCRIPTION
Just adding a section to the docs about how to use the Docker image.

I've pushed my build of the image to Docker Hub under the name [djjudas21/photo_prism_yaml_to_exif](https://hub.docker.com/repository/docker/djjudas21/photo_prism_yaml_to_exif/general) which is available for anyone to use.

Feel free to change any of the wording etc to suit your purposes, build your own Docker image, etc.