### PR TITLE
Handle file names with multiple dots/periods

### DIFF
--- a/photo_prism_yaml_to_exif.pl
+++ b/photo_prism_yaml_to_exif.pl
@@ -234,7 +234,7 @@ sub process_file {
     }
 
     # get the yaml filename for the image file...
-    my $filename_yaml = $filename_image =~ s/\..*?$/\.yml/r;
+    my $filename_yaml = $filename_image =~ s/\.[^.]+$/.yml/r;
     log_trace('$filename_yaml: "%s"', $filename_yaml);
 
     # get the full path to the YAML file


### PR DESCRIPTION
The current code will fail for files with multiple dots/periods in the file name, since it will only match the first dot. This should fix that.